### PR TITLE
requestHeaders has error value

### DIFF
--- a/lib/Swoole/Client/HTTP.php
+++ b/lib/Swoole/Client/HTTP.php
@@ -226,7 +226,7 @@ class HTTP extends Base {
 
 		//设置请求headers信息
 		if (!empty($headers)) {
-			$this ->requestHeaders = $this ->setRequestHeaders($headers);
+			$this ->setRequestHeaders($headers);
 		}
 
 		$this ->buildRequest();


### PR DESCRIPTION
setRequestHeaders中已经循环赋值，并且没有返回值。
