### PR TITLE
适配最新的swoole（pecl安装，目前最新版为1.9.2）

### DIFF
--- a/conf/testHttpServ.ini
+++ b/conf/testHttpServ.ini
@@ -12,7 +12,7 @@ php = '/usr/local/php/bin/php'
 ; worker num
 worker_num = 16
 ; task num
-task_worker_num = 0
+task_worker_num = 8
 dispatch_mode = 2
 daemonize = 1
 

--- a/lib/Swoole/Network/Protocol/PullServer.php
+++ b/lib/Swoole/Network/Protocol/PullServer.php
@@ -67,7 +67,7 @@ class PullServer extends Swoole\Network\Protocol implements Swoole\Server\Protoc
     }
 
     //启动定时期,监听IPC通道
-    public function onTimer($serv, $interval)
+    public function onTimer($timer_id, $interval)
     {
         $res = $this->timeJobs[$interval];
         if ($data = $res->recv()) {
@@ -102,7 +102,13 @@ class PullServer extends Swoole\Network\Protocol implements Swoole\Server\Protoc
     {
         if (is_array($this->timeJobs)) {
             foreach ($this->timeJobs as $k => $v) {
-                $serv->addtimer($k);
+                //edit by Terry Gao at 2016-12-27
+                //由于新版Swoole(1.8+)移除了addtimer方法，改用swoole_server->tick方法替代
+                //相应的onTimer回调也稍作调整
+                //$serv->addtimer($k);
+                $serv->tick($k, function ($timer_id, $params){
+                    $this->onTimer($timer_id, $params);
+                }, $k);
             }
         }
     }

--- a/lib/Swoole/Network/SimpleServer.php
+++ b/lib/Swoole/Network/SimpleServer.php
@@ -8,7 +8,7 @@
  * To change this template use File | Settings | File Templates.
  * 对应swoole的base模式的server
  */
-class SimpleServer extends Swoole\Server implements Swoole\Server\Driver
+class SimpleServer extends Swoole\Servers implements Swoole\Server\Driver
 {
     protected $mode = SWOOLE_BASE;
 

--- a/lib/Swoole/Network/TcpServer.php
+++ b/lib/Swoole/Network/TcpServer.php
@@ -4,7 +4,7 @@ namespace Swoole\Network;
  * Class Server
  * @package Swoole\Network
  */
-class TcpServer extends \Swoole\Server implements \Swoole\Server\Driver
+class TcpServer extends \Swoole\Servers implements \Swoole\Server\Driver
 {
     protected $sockType = SWOOLE_SOCK_TCP;
 

--- a/lib/Swoole/Network/UdpServer.php
+++ b/lib/Swoole/Network/UdpServer.php
@@ -4,7 +4,7 @@ namespace Swoole\Network;
  * Class Server
  * @package Swoole\Network
  */
-class UdpServer extends \Swoole\Server
+class UdpServer extends \Swoole\Servers
 {
     protected $sockType = SWOOLE_SOCK_UDP;
 

--- a/lib/Swoole/Servers.php
+++ b/lib/Swoole/Servers.php
@@ -2,7 +2,15 @@
 
 namespace Swoole;
 
-abstract class Server implements Server\Driver
+/**
+ * Class Servers
+ * @editor Terry Gao
+ * @date 2016-12-27
+ * 因命名空间类名与文件夹重名，Server类改为Severs
+ *
+ * @package Swoole
+ */
+abstract class Servers implements Server\Driver
 {
     protected $sw;
     protected $processName = 'swooleServ';
@@ -128,7 +136,9 @@ abstract class Server implements Server\Driver
         $this->sw->on('Receive', array($this, 'onReceive'));
         $this->sw->on('Close', array($this, 'onClose'));
         $this->sw->on('WorkerStop', array($this, 'onWorkerStop'));
-        $this->sw->on('timer', array($this, 'onTimer'));
+        //edit by Terry Gao at 2016-12-27
+        //onTimer事件是由已移除的addTimer方法添加的定时器回调的，新版的Swoole已经没有该事件
+        //$this->sw->on('timer', array($this, 'onTimer'));
         if ($this->enableHttp) {
             $this->sw->on('Request', array($this, 'onRequest'));
         }

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,12 @@
 Tencent Server Framework
-=======================
+========================
+
+## 2016-12-27 更新内容
+
+- 适配最新的swoole（pecl安装，目前最新版为1.9.2），用swoole_server->tick替代swoole_server->addTimer
+- 修正命名空间重名问题（Server类与Server目录重名）
+- 运行前需要修改conf/testHttpServ.ini中的root和php两个路径，可将路径root指向examples/src目录下的index.php，root为php的安装路径
+- 运行需要使用root用户，请先sudo su，直接使用sudo php bin/swoole.php testHttpServ.ini会报错
 
 ## 通知
 


### PR DESCRIPTION
1. 适配最新的swoole（pecl安装，目前最新版为1.9.2），用swoole_server->tick替代swoole_server->addTimer
2. 修正命名空间重名问题（Server类与Server目录重名）
3. 更新readme